### PR TITLE
Update cargo audit command to ignore specific advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Run cargo audit
-        run: cargo audit
+        run: cargo audit --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2023-0071
 
   coverage:
     name: Code coverage


### PR DESCRIPTION
Add ignore flags for specific Rust security advisories in cargo audit.